### PR TITLE
feat: add new blog post reference for background jobs

### DIFF
--- a/docs/_blogposts/gain-insights-into-databricks-jobs-with-arcus-background-jobs.md
+++ b/docs/_blogposts/gain-insights-into-databricks-jobs-with-arcus-background-jobs.md
@@ -1,0 +1,6 @@
+---
+title: "Gain Insights into Databricks Jobs with Arcus Background Jobs"
+date: 2020-06-03T11:10:00
+description: Beginning with Arcus Background Jobs v0.2 we introduced a new library to monitor Databricks clusters. The challenge with Databricks clusters in Azure is that they do not provide out-of-the-box job metrics in Azure Monitor which makes it hard to operate them. This post will show you how our new version of the Arcus Background Jobs library will help you with this problem so the next time you run a Databricks job, you'll be notified right away!
+articleUrl: https://www.codit.eu/blog/databricks-jobs-arcus-background-jobs/
+---


### PR DESCRIPTION
The new blog post was released https://www.codit.eu/blog/databricks-jobs-arcus-background-jobs/.