### PR TITLE
chore: update with Arcus owner mail

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -51,7 +51,7 @@ clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported
-by contacting the project team at tom.kerkhove@codit.eu. The project team will
+by contacting the project team at dirk.luyckx@codit.eu. The project team will
 review and investigate all complaints, and will respond in a way that it deems
 appropriate to the circumstances. The project team is obligated to maintain confidentiality
 with regard to the reporter of an incident. Further details of specific enforcement


### PR DESCRIPTION
Update the Arcus owner mail in code of conduct.