### PR TITLE
feat: add web api v1.5 blog post reference

### DIFF
--- a/docs/_blogposts/interesting-new-hooks-and-net6-support-in-arcus-webapi-v1.5.md
+++ b/docs/_blogposts/interesting-new-hooks-and-net6-support-in-arcus-webapi-v1.5.md
@@ -1,0 +1,6 @@
+---
+title: "Interesting New Hooks and .NET 6 Support in Arcus WebAPI v1.5"
+date: 2022-04-21T10:01:00+2:00
+description: Lots of interesting new features are now available in Arcus WebAPI. This blog post will give a run-down of a few of them.
+articleUrl: https://www.codit.eu/blog/interesting-new-hooks-and-net-6-support-in-arcus-webapi-v1-5/
+---


### PR DESCRIPTION
Add blog post reference for the published Arcus Web API v1.5 blog post.

Closes #200 