### PR TITLE
docs: add blog post reference for Arcus Scripting v0.6

### DIFF
--- a/docs/_blogposts/finished-azure-integration-account-functionality-and-other-cool-features-in-arcus-scripting-v0.6.md
+++ b/docs/_blogposts/finished-azure-integration-account-functionality-and-other-cool-features-in-arcus-scripting-v0.6.md
@@ -1,0 +1,6 @@
+---
+title: "Finished Azure Integration Account Functionality and Other Cool Features in Arcus Scripting v0.6"
+date: 2022-05-05T10:00:00+10:00
+description: Recently, we released Arcus Scripting v0.6. The scripting library was quiet for a while, without any updates, so let's see what's new in this run-down post on the upcoming functionalities
+articleUrl: https://www.codit.eu/blog/finished-azure-integration-account-functionality-and-other-cool-features-in-arcus-scripting-v0-6/
+---


### PR DESCRIPTION
Adds blog post reference for Arcus Scripting v0.6.

Closes #203 