### PR TITLE
feat: add v1.6 web api blog post reference

### DIFF
--- a/docs/_blogposts/automatic-http-client-correlation-tracking-in-arcus-webapi-v1.6.md
+++ b/docs/_blogposts/automatic-http-client-correlation-tracking-in-arcus-webapi-v1.6.md
@@ -1,0 +1,6 @@
+---
+title: "Automatic HTTP Client Correlation Tracking in Arcus WebAPI v1.6"
+date: 2022-09-29T10:10:00+10:00
+description: Arcus WebAPI v1.6 is all about service-to-service correlation. Both the sending and receiving sides have been updated with cool features to ease the complexity of HTTP correlation.
+articleUrl: https://www.codit.eu/blog/automatic-http-client-correlation-tracking-in-arcus-webapi-v1-6/
+---


### PR DESCRIPTION
Add new blog post reference for Arcus WebAPI v1.6 release.