### PR TITLE
docs: add webapi v1.7 blog ref

### DIFF
--- a/website/resources/posts/Arcus Web API v1.7 A Release with Improvements Like Never Before.md
+++ b/website/resources/posts/Arcus Web API v1.7 A Release with Improvements Like Never Before.md
@@ -1,0 +1,6 @@
+---
+title: "Arcus Web API v1.7: A Release with Improvements Like Never Before"
+date: 2022-12-29T09:03:00+10:00
+description: "Arcus Web API v1.7: A Release with Improvements Like Never Before"
+articleUrl: https://www.codit.eu/blog/arcus-web-api-v1-7-a-release-with-improvements-like-never-before/
+---


### PR DESCRIPTION
Add blog post reference for Arcus Web API v1.7 blog post.

Closes #256