### PR TITLE
chore: add observability v3.0 blog post ref

### DIFF
--- a/website/resources/posts/First Arcus Observability Release of 2024 Starts with a Bang.md
+++ b/website/resources/posts/First Arcus Observability Release of 2024 Starts with a Bang.md
@@ -1,0 +1,6 @@
+---
+title: "First Arcus Observability Release of 2024 Starts with a Bang"
+date: 2024-02-15T12:33:46+10:00
+description: The inaugural Arcus release of 2024 marks a significant milestone for the Arcus Observability library. In this post, we'll delve into the notable highlights.
+articleUrl: https://www.codit.eu/blog/first-arcus-observability-release-of-2024-starts-with-a-bang/
+---


### PR DESCRIPTION
Adds a blog post reference now that the post is published: https://www.codit.eu/blog/first-arcus-observability-release-of-2024-starts-with-a-bang/.

Closes #345