### PR TITLE
chore: remove deprecated repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,11 @@ We track issues in a variety of places for Arcus. If you have found an issue or 
 | Area           | Description                                             | Link                   |
 |:---------------|:--------------------------------------------------------|:----------------------:|
 | **General**    | General request or suggestions for new areas            | [File an Issue](https://github.com/arcus-azure/arcus/issues) |
-| **Event Grid** | Requests & suggestions for Azure Event Grid integration | [Features](https://eventgrid.arcus-azure.net/#features) - [File an Issue](https://github.com/arcus-azure/arcus.eventgrid/issues)
-| **Event Grid Sidecar** | Requests & suggestions for Azure Event Grid Docker container | [Features](https://eventgrid-sidecar.arcus-azure.net/#features) - [File an Issue](https://github.com/arcus-azure/arcus.eventgrid.sidecar/issues)
 | **Security** | Requests & suggestions for security integration(s) | [Features](https://security.arcus-azure.net/#features) - [File an Issue](https://github.com/arcus-azure/arcus.security/issues)
 | **Web API** | Requests & suggestions for web api development | [Features](https://webapi.arcus-azure.net/#features) - [File an Issue](https://github.com/arcus-azure/arcus.webapi/issues)
 | **Messaging** | Requests & suggestions for messaging development | [Features](https://messaging.arcus-azure.net/#features) - [File an Issue](https://https://github.com/arcus-azure/arcus.messaging/issues)
-| **Background Jobs** | Requests & suggestions for reusable jobs & development of background jobs | [Features](https://background-jobs.arcus-azure.net/#features) - [File an Issue](https://github.com/arcus-azure/arcus.backgroundjobs/issues)
 | **Observability** | Requests & suggestions for adding observability to applications | [Features](https://observability.arcus-azure.net/#features) - [File an Issue](https://github.com/arcus-azure/arcus.observability/issues)
 | **.NET Templates** | Requests & suggestions for .NET templates to get started | [Features](https://templates.arcus-azure.net/#features) - [File an Issue](https://github.com/arcus-azure/arcus.templates/issues)
-| **Machine Learning** | Requests & suggestions for machine learning | [Features](https://machine-learning.arcus-azure.net/#features) - [File an Issue](https://github.com/arcus-azure/arcus.ml/issues)
-| **Azure Machine Learning** | Requests & suggestions for machine learning in Azure | [Features](https://azure-ml.arcus-azure.net/#features) - [File an Issue](https://github.com/arcus-azure/arcus.azureml/issues)
 
  ## Starting a new components
  

--- a/website/resources/components/background-jobs.md
+++ b/website/resources/components/background-jobs.md
@@ -1,7 +1,0 @@
----
-title: Arcus Background Jobs
-description: Strengthen your application with commonly repeated tasks ranging from automatic secret invalidation of Azure Key Vault secrets to publishing events on Azure EventGrid and more.
-github: https://github.com/arcus-azure/arcus.backgroundjobs
-documentation: https://background-jobs.arcus-azure.net/
-type: component
----

--- a/website/resources/components/observability.md
+++ b/website/resources/components/observability.md
@@ -1,7 +1,0 @@
----
-title: Arcus Observability
-description: Track Azure Application Insights dependencies, log custom metrics, and log multi-dimensional telemetry data via the common ILogger infrastructure.
-github: https://github.com/arcus-azure/arcus.observability
-documentation: https://observability.arcus-azure.net/
-type: component
----

--- a/website/resources/components/security.md
+++ b/website/resources/components/security.md
@@ -1,7 +1,0 @@
----
-title: Arcus Security
-description: Retrieve secrets safely via a dedicated secret store instead of placing sensitive information in your application's configuration.
-github: https://github.com/arcus-azure/arcus.security
-documentation: https://security.arcus-azure.net/
-type: component
----


### PR DESCRIPTION
* Remove deprecated repo's from the website.
* Focus on 'end' repos instead of 'dependent' repo's like security or observability.